### PR TITLE
Improve robustness of bulk create endpoint

### DIFF
--- a/backend/base/api/views.py
+++ b/backend/base/api/views.py
@@ -131,6 +131,10 @@ class BulkCreateBooksAndChaptersAPIView(APIView):
         response_data = {}
         books_to_create = []
         chapters_to_create = []
+        if is_single_book:
+            books_data = [books_data]
+        if is_single_chapter:
+            chapters_data = [chapters_data]
         for book_data in books_data:
             title = book_data.get('title')
             existing_books = Book.objects.filter(title=title)


### PR DESCRIPTION
Adjusted the bulk create endpoint in the BulkCreateBooksAndChaptersAPIView class to handle cases where the payload for books or chapters may be a single object instead of a list. Added checks to determine if the payload is a single object and adjusted the processing logic accordingly to ensure the endpoint works correctly in all scenarios.